### PR TITLE
Add scene switching between Main Menu, Story Scene, and Main Game Scene

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Milaugh"
-run/main_scene="res://scenes/main_game_scene.tscn"
+run/main_scene="res://scenes/top_node_scene.tscn"
 config/features=PackedStringArray("4.2")
 boot_splash/bg_color=Color(0.145098, 0.12549, 0.203922, 1)
 boot_splash/image="res://art/Robots/JokerRobot.png"

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=7 format=3 uid="uid://idbruavivbvn"]
+[gd_scene load_steps=8 format=3 uid="uid://idbruavivbvn"]
 
+[ext_resource type="Script" path="res://scripts/main_menu.gd" id="1_ecgof"]
 [ext_resource type="Texture2D" uid="uid://bwlfd3aa8q3w6" path="res://ui_images/border_trim.png" id="1_ifybn"]
 [ext_resource type="Texture2D" uid="uid://bwrt333tfcmlq" path="res://ui_images/blank_ui.png" id="2_82qj0"]
 [ext_resource type="FontFile" uid="uid://6m88uyjxpw1y" path="res://font/joystix monospace.otf" id="2_nad3f"]
@@ -21,6 +22,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_ecgof")
 
 [node name="bg" type="NinePatchRect" parent="."]
 layout_mode = 1
@@ -65,3 +67,5 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_1p3f8")
 theme_override_styles/hover = SubResource("StyleBoxFlat_s843a")
 text = "Play"
 metadata/_edit_use_anchors_ = true
+
+[connection signal="pressed" from="bg/button_play" to="." method="_on_button_play_pressed"]

--- a/scenes/root.tscn
+++ b/scenes/root.tscn
@@ -1,9 +1,0 @@
-[gd_scene format=3 uid="uid://ccjt6sikt8ub8"]
-
-[node name="Root" type="Control"]
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2

--- a/scenes/story_scene.tscn
+++ b/scenes/story_scene.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://bpus1miu4qx71"]
+[gd_scene load_steps=7 format=3 uid="uid://bpus1miu4qx71"]
 
 [ext_resource type="Texture2D" uid="uid://bwlfd3aa8q3w6" path="res://ui_images/border_trim.png" id="1_0ucix"]
+[ext_resource type="Script" path="res://scripts/story_scene.gd" id="1_7dlu3"]
 [ext_resource type="Theme" uid="uid://cv5o7uq4xg1rr" path="res://themes/pixel_font_theme.tres" id="2_vmukq"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_0cj81"]
@@ -19,6 +20,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_7dlu3")
 
 [node name="bg" type="NinePatchRect" parent="."]
 layout_mode = 0
@@ -74,3 +76,5 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_24c1i")
 theme_override_styles/hover = SubResource("StyleBoxFlat_j41eo")
 text = "Play"
 metadata/_edit_use_anchors_ = true
+
+[connection signal="pressed" from="bg/button_play" to="." method="_on_button_play_pressed"]

--- a/scenes/top_node_scene.tscn
+++ b/scenes/top_node_scene.tscn
@@ -1,19 +1,24 @@
-[gd_scene load_steps=5 format=3 uid="uid://bswhhw0a051ds"]
+[gd_scene load_steps=6 format=3 uid="uid://bswhhw0a051ds"]
 
 [ext_resource type="PackedScene" uid="uid://idbruavivbvn" path="res://scenes/main_menu.tscn" id="1_0k6el"]
+[ext_resource type="Script" path="res://scripts/top_node_scene.gd" id="1_am5rq"]
 [ext_resource type="PackedScene" uid="uid://bpus1miu4qx71" path="res://scenes/story_scene.tscn" id="2_qx7ql"]
 [ext_resource type="PackedScene" uid="uid://bb6hv48hppt78" path="res://scenes/main_game_scene.tscn" id="3_qd35k"]
 [ext_resource type="PackedScene" uid="uid://s4oi1oh2dv47" path="res://scenes/result_scene.tscn" id="4_v861w"]
 
 [node name="top_node_scene" type="Node"]
+script = ExtResource("1_am5rq")
 
 [node name="main_menu" parent="." instance=ExtResource("1_0k6el")]
 
 [node name="story_scene" parent="." instance=ExtResource("2_qx7ql")]
 visible = false
 
-[node name="main_game_scene_zach" parent="." instance=ExtResource("3_qd35k")]
+[node name="main_game_scene" parent="." instance=ExtResource("3_qd35k")]
 visible = false
 
 [node name="result_scene" parent="." instance=ExtResource("4_v861w")]
 visible = false
+
+[connection signal="start_game" from="main_menu" to="." method="_on_main_menu_start_game"]
+[connection signal="start_game" from="story_scene" to="." method="_on_story_scene_start_game"]

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -1,0 +1,17 @@
+extends Control
+
+signal start_game
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+
+func _on_button_play_pressed():
+	emit_signal("start_game")
+	pass # Replace with function body.

--- a/scripts/story_scene.gd
+++ b/scripts/story_scene.gd
@@ -1,0 +1,17 @@
+extends Control
+
+signal start_game
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+
+func _on_button_play_pressed():
+	emit_signal("start_game")
+	pass # Replace with function body.

--- a/scripts/top_node_scene.gd
+++ b/scripts/top_node_scene.gd
@@ -1,0 +1,23 @@
+extends Node
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+
+func _on_main_menu_start_game():
+	$main_menu.visible = false
+	$story_scene.visible = true
+	pass # Replace with function body.
+
+
+func _on_story_scene_start_game():
+	$story_scene.visible = false
+	$main_game_scene.visible = true
+	pass # Replace with function body.


### PR DESCRIPTION
Also changes default scene back to Top Node Scene, where the scene switching is implemented.

Does not yet allow switching from Main Game Scene to Result Scene - need to establish the logic for this first.